### PR TITLE
Build Lambda with External Node Modules

### DIFF
--- a/infrastructure/codepipeline.yaml
+++ b/infrastructure/codepipeline.yaml
@@ -74,6 +74,7 @@ Resources:
                       commands:
                         - npm install
                         - make build
+                        - cp -r node_modules/ dist/node_modules/
                         - aws cloudformation package --template-file template.yaml --s3-bucket $S3BUCKET --output-template-file outputtemplate.yaml
                   artifacts:
                     type: zip


### PR DESCRIPTION
This PR adds a step in the build stage of the code pipeline. This step copies the `node_modules/` into the `dist/` folder which will bundle them with the Lambda `.zip` file when it is deployed.