### PR TITLE
revert the previous commit - "Added an S3 bucket, testing"

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -40,9 +40,6 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: 'data-table'
 
-  S3Bucket:
-    Type: AWS::S3::Bucket
-
   DataTable:
     Type: AWS::DynamoDB::Table
     Properties:


### PR DESCRIPTION
The IAM role titled 'CodePipelineServiceRole' (within `infrastructure\roles.yaml`) does not have 's3:CreateBucket' permission and therefore the deployment of the stack fails.

This reverts commit 112b4181728d8c6d49c0f6f24a0252a19da5c6f9. 